### PR TITLE
add backend Dockerfile for Render deployment

### DIFF
--- a/diplomski-back/Dockerfile
+++ b/diplomski-back/Dockerfile
@@ -1,0 +1,16 @@
+FROM maven:3.8.8-eclipse-temurin-8 AS build
+WORKDIR /app
+
+COPY pom.xml .
+COPY src ./src
+
+RUN mvn -B -DskipTests clean package
+
+FROM eclipse-temurin:8-jre
+WORKDIR /app
+
+COPY --from=build /app/target/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
Use a multi-stage Java 8 image to build and run the Spring Boot API in environments where native Java runtime selection is unavailable.